### PR TITLE
Add a 'skip to main' common element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ open data applications.
 
 ## Changes
 
+## 1.6.0 - 2020-09-22 (Ian)
+
+- added skip-to-main-content partial
+
 ## 1.5.0 - 2020-09-14 (Ian)
 
 A number of changes in support of improved WCAG compliance (GH-15):

--- a/app/assets/stylesheets/_skip_to_main.scss
+++ b/app/assets/stylesheets/_skip_to_main.scss
@@ -1,0 +1,22 @@
+.u-off-canvas {
+  position: absolute;
+  left: -999rem;
+  top: -999rem;
+
+  @media print {
+    display: none;
+  }
+}
+
+.u-off-canvas--focusable {
+  &:focus {
+    left: 0;
+    top: 0;
+  }
+}
+
+.c-skip-to-main {
+  background: white;
+  padding: 1rem;
+  z-index: 9999;
+}

--- a/app/assets/stylesheets/lr_common_styles/_lr-common.scss
+++ b/app/assets/stylesheets/lr_common_styles/_lr-common.scss
@@ -34,7 +34,8 @@ $lr-green-nav-darkened: darken( $lr-green-nav, 20% );
 @import
   'header',
   'footer',
-  'feedback';
+  'feedback',
+  'skip_to_main';
 
 .o-container {
   @extend %site-width-container;

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -33,6 +33,8 @@
       %script{ src: "assets/respond.min.js", type: "application/javascript"}
 
   %body{ class: "government website lr #{LrCommonConfig.application_css_class}" }
+    = render partial: 'shared/skip_to_main_content'
+
     %header#global-header.with-proposition.lr-header{ role: "banner" }
       .header-wrapper
         .header-global
@@ -61,7 +63,7 @@
 
     -# =render partial: "common/flash_message"
 
-    %main.container.o-container{ role: "main"}
+    %main#main-content.container.o-container{ role: "main"}
       .row
         .col-md-12
           = yield

--- a/app/views/shared/_skip_to_main_content.html.haml
+++ b/app/views/shared/_skip_to_main_content.html.haml
@@ -1,0 +1,3 @@
+%nav.c-skip-to-main{ 'aria-label' => 'skip to main content'}
+  %a.c-skip-to-main__action.u-off-canvas.u-off-canvas--focusable{ href: '#main-content' }
+    Skip to main content

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -2,7 +2,7 @@
 
 module LrCommonStyles
   MAJOR = 1
-  MINOR = 5
+  MINOR = 6
   PATCH = 0
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
 end


### PR DESCRIPTION
Adding a shared component for placing a 'skip to main content' link on
each page, to assist users of keyboard navigation.