### PR TITLE
Cookie permissions dialog

### DIFF
--- a/app/assets/javascripts/lr_common_styles/application.js
+++ b/app/assets/javascripts/lr_common_styles/application.js
@@ -1,0 +1,1 @@
+//= require_tree .

--- a/app/assets/javascripts/lr_common_styles/cookie.js
+++ b/app/assets/javascripts/lr_common_styles/cookie.js
@@ -1,0 +1,101 @@
+const HMLR_COOKIE_POLICY = 'hmlr_cookie_policy'
+const COOKIE_DURATION = 365
+
+/**
+ * Retrieve user preferences cookie
+ * If user has accepted analytics, load analytics
+ * If no preference is set, show cookie banner
+ */
+window.onload = function () {
+  var userPreferences = getCookie(HMLR_COOKIE_POLICY)
+  if (userPreferences) {
+    var analyticsAccepted = JSON.parse(userPreferences).analytics
+
+    if (analyticsAccepted) {
+      loadAnalytics()
+    }
+  } else {
+    showBanner(true)
+  }
+}
+
+/**
+ * standard function for setting a cookie with an expiry length in days
+ * @param {string} key
+ * @param {string} value 
+ * @param {number} duration in days
+ */
+function setCookie(key, value, duration) {
+  var date = new Date();
+  date.setTime(date.getTime() + duration * 24 * 60 * 60 * 1000);
+  var expires = 'expires=' + date.toUTCString();
+  document.cookie = key + '=' + value + ';' + expires + ';path=/'
+}
+
+/**
+ * retrieves a cookie's value by name
+ * @param {string} name 
+ * @returns {string} the value of the cookie
+ */
+function getCookie(name) {
+  var key = name + '='
+  var decodedCookie = decodeURIComponent(document.cookie)
+  var cookieList = decodedCookie.split(';')
+  for (var i = 0; i < cookieList.length; i++) {
+    var cookie = cookieList[i]
+    while (cookie.charAt(0) == ' ') {
+      cookie = cookie.substring(1)
+    }
+    if (cookie.indexOf(key) == 0) {
+      return cookie.substring(key.length, cookie.length)
+    }
+  }
+  return ''
+}
+
+/**
+ * Set analytics acceptance cookie to true
+ */
+function acceptCookie() {
+  acceptAnalytics(true)
+}
+
+/**
+ * Set analytics acceptance cookie to false
+ */
+function rejectCookie() {
+  acceptAnalytics(false)
+}
+
+/**
+ * Toggle visibility of cookie banner in the UI
+ * @param {boolean} bool 
+ */
+function showBanner(bool) {
+  var cookieBanner = document.querySelector('#cookie-banner')
+
+  if (bool) {
+    cookieBanner.setAttribute('style', 'display:block')
+  } else {
+    cookieBanner.setAttribute('style', 'display:none')
+  }
+}
+
+/**
+ * Set analytics cookie and if true load analytics
+ * @param {boolean} bool 
+ */
+function acceptAnalytics(bool) {
+  var preferences = { analytics: bool }
+
+  setCookie(HMLR_COOKIE_POLICY, JSON.stringify(preferences), COOKIE_DURATION)
+  showBanner(false)
+
+  if (bool) {
+    loadAnalytics()
+  }
+}
+
+function loadAnalytics() {
+  // do something
+}

--- a/app/assets/javascripts/lr_common_styles/cookie.js
+++ b/app/assets/javascripts/lr_common_styles/cookie.js
@@ -96,6 +96,14 @@ function acceptAnalytics(bool) {
   }
 }
 
+/**
+ * Code snip for initialising Google Tag Manager requires
+ * gtag js.
+ */
 function loadAnalytics() {
   // do something
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+  gtag('config', 'UA-21165003-6' , { 'anonymize_ip': true });
 }

--- a/app/assets/stylesheets/lr_common_styles/_cookie-banner.scss
+++ b/app/assets/stylesheets/lr_common_styles/_cookie-banner.scss
@@ -1,0 +1,28 @@
+.cookie-banner {
+  font-size: 1.2em;
+  margin: 0 auto;
+  padding: 1rem;
+
+  & > * + * {
+    margin-top: 0.5em;
+  }
+  
+  &__heading {
+    font-size: 1.1em;
+    font-weight: bold;
+    margin: 0;
+  }
+
+  button {
+    border: none;
+    padding: 0.25em 0.5em;
+  }
+
+  &__accept {
+    background-color: $lr-green-nav;
+  }
+
+  &__reject {
+    background-color: $lr-logo-grey;
+  }
+}

--- a/app/assets/stylesheets/lr_common_styles/_lr-common.scss
+++ b/app/assets/stylesheets/lr_common_styles/_lr-common.scss
@@ -4,12 +4,12 @@
 
 /* variables */
 
-$lr-green-dark: #5A8006;
+$lr-green-dark: #5a8006;
 $lr-yellow: #e5ea08;
 $lr-logo-green-light: #a6d71c;
 $lr-logo-green-dark: #66c430;
 $lr-logo-grey: #a7a5a6;
-$lr-green-nav: #ACCD40;
+$lr-green-nav: #accd40;
 $semi-black: #202222;
 
 $lr-headline: $lr-green-dark;
@@ -19,19 +19,20 @@ $lr-link-quiet: $lr-logo-green-light;
 $lr-focus: $lr-logo-green-dark;
 $lr-top-line: $lr-green-nav;
 $lr-footer-grey: #f0f5f0;
-$lr-footer-link: lighten( $lr-separator, 10 );
+$lr-footer-link: lighten($lr-separator, 10);
 $lr-footer-background: #818181;
-$lr-green-nav-darkened: darken( $lr-green-nav, 20% );
+$lr-green-nav-darkened: darken($lr-green-nav, 20%);
 
 /* settings */
 
 /* elements */
 
-@import "common-elements";
+@import 'common-elements';
 
 /* objects */
 
 @import
+  'cookie-banner',
   'header',
   'footer',
   'feedback',
@@ -51,5 +52,5 @@ $lr-green-nav-darkened: darken( $lr-green-nav, 20% );
   font-weight: bold;
 }
 
-@import "gov_uk_refine";
-@import "bootstrap-refine";
+@import 'gov_uk_refine';
+@import 'bootstrap-refine';

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -34,6 +34,7 @@
       %script{ src: "assets/respond.min.js", type: "application/javascript"}
 
   %body{ class: "government website lr lr-app" }
+    = render partial: "shared/cookie_banner"
     = render partial: 'shared/skip_to_main_content'
 
     %header#global-header.with-proposition.lr-header{ role: "banner" }
@@ -71,4 +72,3 @@
           = render partial: "shared/feedback"
 
     = render partial: "shared/footer"
-    = render partial: "shared/cookie_banner"

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -71,3 +71,4 @@
           = render partial: "shared/feedback"
 
     = render partial: "shared/footer"
+    = render partial: "shared/cookie_banner"

--- a/app/views/shared/_cookie_banner.html
+++ b/app/views/shared/_cookie_banner.html
@@ -15,13 +15,15 @@
     They help us understand how you use this site, like which pages you visit.
     <br/>
     For more information, view our
-    <a
-      href="#"
-      target="_blank"
-      class="cookie-banner__statement-link"
-    >
-      cookie statement
-    </a>
+      <a
+        href="#"
+        target="_blank"
+        rel="external"
+        class="cookie-banner__statement-link"
+      >
+          cookie statement
+        </span>
+      </a>
   </p>
   <button
     class="cookie-banner__accept"

--- a/app/views/shared/_cookie_banner.html
+++ b/app/views/shared/_cookie_banner.html
@@ -1,0 +1,38 @@
+<div
+  id="cookie-banner"
+  class="cookie-banner"
+  style="display: none"
+>
+  <h2
+    class="cookie-banner__heading"
+  >
+    This site uses cookies
+  </h2>
+  <p
+    class="cookie-banner__details"
+  >
+    Cookies are files stored on your computer, phone, or tablet.
+    They help us understand how you use this site, like which pages you visit.
+    <br/>
+    For more information, view our
+    <a
+      href="#"
+      target="_blank"
+      class="cookie-banner__statement-link"
+    >
+      cookie statement
+    </a>
+  </p>
+  <button
+    class="cookie-banner__accept"
+    onclick="acceptCookie()"
+  >
+    Accept additional cookies
+  </button>
+  <button
+    class="cookie-banner__reject"
+    onclick="rejectCookie()"
+  >
+    Reject additional cookies
+  </button>
+</div>

--- a/app/views/shared/_cookie_banner.html
+++ b/app/views/shared/_cookie_banner.html
@@ -12,18 +12,7 @@
     class="cookie-banner__details"
   >
     Cookies are files stored on your computer, phone, or tablet.
-    They help us understand how you use this site, like which pages you visit.
-    <br/>
-    For more information, view our
-      <a
-        href="#"
-        target="_blank"
-        rel="external"
-        class="cookie-banner__statement-link"
-      >
-          cookie statement
-        </span>
-      </a>
+    They help us understand how you use this site, such as which pages you visit.
   </p>
   <button
     class="cookie-banner__accept"

--- a/app/views/shared/_google-analytics.html
+++ b/app/views/shared/_google-analytics.html
@@ -1,8 +1,2 @@
 <!-- Global Site Tag (gtag.js) - Google Analytics -->
 <script async src="https://www.googletagmanager.com/gtag/js?id=UA-21165003-6"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-  gtag('config', 'UA-21165003-6' , { 'anonymize_ip': true });
-</script>


### PR DESCRIPTION
Adds cookie permissions dialog that will check for a cookie named 'hmlr_policy' with a property 'analytics' property set to true or false.
If no such cookie is present the dialog will appear atop the page, else user permitting the Google Tag Manager will be initialised.

epimorphics/hmlr-linked-data#20
