### PR TITLE
Collective lift and shift updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,16 @@ applications.
 
 ## Changes
 
-## 1.9.1
+## 1.9.1.1 - 2023-03-10
 
-### 2023-03
+- (Jon) Updated the gemspec to ensure the gem is locked to the same 2.6.6 ruby
+  version to reduce any potential issues with current app integrations
+- (Jon) Removed dependency version locks due to connected apps not supporting
+  newer versions of gems being used.
+- (Jon) Updated version cadence using new suffix to reflect the adjustments with
+  development and build dependency approach
+
+## 1.9.1 - 2023-03-07
 
 - (Jon) Updated the gemspec to ensure the dependency versions are locked to
   specific base versions to avoid any potential issues with the gem being used

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ applications.
 
 ### 2023-03
 
+- (Jon) Updated the gemspec to ensure the dependency versions are locked to
+  specific base versions to avoid any potential issues with the gem being used
 - (Jon) Minor text changes to the .gemspec file to update the summary
   field to mirror the common fields set in other gems.
 - (Jon) Refactored the version cadence creation to include a SUFFIX value if

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,22 @@
 # LR common styles
 
-A Ruby gem to share common styles and assets among the various LR
-open data applications.
+A Ruby gem to share common styles and assets among the various LR open data
+applications.
 
 ## Changes
+
+## 1.9.1
+
+### 2023-03
+
+- (Jon) Minor text changes to the .gemspec file to update the summary
+  field to mirror the common fields set in other gems.
+- (Jon) Refactored the version cadence creation to include a SUFFIX value if
+  provided; otherwise no SUFFIX is included in the version number.
+
+## 1.9.0
+
+- 2022-03-22 (Ian) Add support for publishing gem to GPR
 
 ## 1.8.5
 
@@ -35,8 +48,8 @@ open data applications.
 
 ## 1.7.1
 
-- 2020-01-21 (Ian) ensure current language selection tag is preserved
-  in menu actions
+- 2020-01-21 (Ian) ensure current language selection tag is preserved in menu
+  actions
 
 ## 1.7.0 - 2020-10-01 (Ian)
 
@@ -64,8 +77,8 @@ A number of changes in support of improved WCAG compliance (GH-15):
 - introducted a new feedback option at the page footer
 - ensured that all links have `aria-label` if needed
 - ensured that all images have alt tags
-- added a local copy of the OGL logo, since the shared used by the
-  gov-uk toolkit has been removed
+- added a local copy of the OGL logo, since the shared used by the gov-uk
+  toolkit has been removed
 
 ## 1.4.12 - 2020-07-06
 
@@ -93,7 +106,7 @@ A number of changes in support of improved WCAG compliance (GH-15):
 
 ## 1.4.0 - 2017-03-30
 
-- Change the Bootstrap standard washed-out red for embedded code fragments
-to something less garish
+- Change the Bootstrap standard washed-out red for embedded code fragments to
+something less garish
 
 - Branding update: change "Land Registry" to "HM Land Registry"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lr_common_styles (1.9.0)
+    lr_common_styles (1.9.1)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)
@@ -209,4 +209,4 @@ DEPENDENCIES
   rails_real_favicon
 
 BUNDLED WITH
-   2.3.5
+   2.4.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lr_common_styles (1.9.1)
+    lr_common_styles (1.9.1.1)
       bootstrap-sass (~> 3.4.0)
       font-awesome-rails (~> 4.7.0.1)
       govuk_elements_rails (~> 2.0.0)

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -4,6 +4,6 @@ module LrCommonStyles
   MAJOR = 1
   MINOR = 9
   PATCH = 1
-  SUFFIX = nil
+  SUFFIX = 1
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,6 +3,7 @@
 module LrCommonStyles
   MAJOR = 1
   MINOR = 9
-  PATCH = 0
-  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}"
+  PATCH = 1
+  SUFFIX = nil
+  VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.2.4'
   s.add_dependency 'sass-rails', '~> 5.0.4'
 
-  s.add_development_dependency 'minitest-rails'
-  s.add_development_dependency 'mocha'
-  s.add_development_dependency 'rails_real_favicon'
+  s.add_development_dependency 'minitest-rails', '~> 5.2', '>=5.2.0'
+  s.add_development_dependency 'mocha', '~> 1.0', '>= 1.13.0'
+  s.add_development_dependency 'rails_real_favicon', '~> 0.1', '>= 0.1.1'
 end

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |s|
   s.authors     = ['Epimorphics Ltd']
   s.email       = ['info@epimorphics.com']
   s.homepage    = 'https://github.com/epimorphics/lr_common_styles'
-  s.summary     = 'Common elements of LR open data applications as a Rails engine'
+  s.summary     = 'LR Common Styles for Rails'
   s.description = 'Common elements of LR open data applications as a Rails engine'
   s.license     = 'MIT'
   s.required_ruby_version = '> 2.6'

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = 'LR Common Styles for Rails'
   s.description = 'Common elements of LR open data applications as a Rails engine'
   s.license     = 'MIT'
-  s.required_ruby_version = '> 2.6'
+  s.required_ruby_version = '= 2.6.6'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 5.2.4'
   s.add_dependency 'sass-rails', '~> 5.0.4'
 
-  s.add_development_dependency 'minitest-rails', '~> 5.2', '>=5.2.0'
-  s.add_development_dependency 'mocha', '~> 1.0', '>= 1.13.0'
-  s.add_development_dependency 'rails_real_favicon', '~> 0.1', '>= 0.1.1'
+  s.add_development_dependency 'minitest-rails'
+  s.add_development_dependency 'mocha'
+  s.add_development_dependency 'rails_real_favicon'
 end


### PR DESCRIPTION
This PR resolves the following points:

- Locks the ruby version to 2.6.6 via the .gemspec file as well as reconfigures gemfile.lock with correct versions for all gems used
-  Minor text changes to the .gemspec file to update the summary field to mirror the common fields set in other gems. 
- Refactored the version cadence creation to include a SUFFIX value if provided; otherwise no SUFFIX is included in the version number.
- Updated the changelog to reflect the change
