### PR TITLE
Root path updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ applications.
 
 ## Changes
 
+## 1.9.1.2 - 2023-04-19
+
+- (Jon)  updated static file setting to current format
+- (Jon)  ensure root path includes /app if in production mode
+- (Jon)  incremented version cadence
+
 ## 1.9.1.1 - 2023-03-10
 
 - (Jon) Updated the gemspec to ensure the gem is locked to the same 2.6.6 ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,7 @@ applications.
 
 ## 1.9.1.2 - 2023-04-19
 
-- (Jon)  updated static file setting to current format
-- (Jon)  ensure root path includes /app if in production mode
+- (Jon)  updated static file settings to current format
 - (Jon)  incremented version cadence
 
 ## 1.9.1.1 - 2023-03-10

--- a/app/models/lr_common_config.rb
+++ b/app/models/lr_common_config.rb
@@ -7,27 +7,24 @@ class LrCommonConfig
     include ActionView::Helpers::UrlHelper
 
     def app_link(app_name, request)
+      # Set the css classes for the link
       css_classes = ['lr-header--header-proposition--a']
+      # If the current url contains the app name, set the active class
       if request.original_url =~ /#{app_name}/
         css_classes << 'lr-header--header-proposition--a__active'
       end
-
       # Sub replaces just the first instance of the app name in the relative_url_root
       path = relative_url_root.sub(%r{[^/]*\Z}, app_name)
       # Add the lang param if it exists
       path += "?lang=#{request.params[:lang]}" if request.params.key?(:lang)
-
+      # Return the link with the css classes and path set accordingly
       link_to(I18n.t("common.app.#{app_name}"), path, class: css_classes.join(' '))
     end
 
     # Returns the relative url root for the app if running in a subdirectory
     # of the web server, or the root if it is not
-    # If the app is running in production, and the relative_url_root excludes
-    # /app, then the app name is appended to the relative_url_root of `/app`
     def relative_url_root
-      root_url = Rails.application.config.relative_url_root || '/'
-      root_url = "/app#{root_url}" if root_url.exclude?('app') && Rails.env.production?
-      root_url
+      Rails.application.config.relative_url_root || '/'
     end
   end
 end

--- a/app/models/lr_common_config.rb
+++ b/app/models/lr_common_config.rb
@@ -12,14 +12,22 @@ class LrCommonConfig
         css_classes << 'lr-header--header-proposition--a__active'
       end
 
+      # Sub replaces just the first instance of the app name in the relative_url_root
       path = relative_url_root.sub(%r{[^/]*\Z}, app_name)
+      # Add the lang param if it exists
       path += "?lang=#{request.params[:lang]}" if request.params.key?(:lang)
 
       link_to(I18n.t("common.app.#{app_name}"), path, class: css_classes.join(' '))
     end
 
+    # Returns the relative url root for the app if running in a subdirectory
+    # of the web server, or the root if it is not
+    # If the app is running in production, and the relative_url_root excludes
+    # /app, then the app name is appended to the relative_url_root of `/app`
     def relative_url_root
-      Rails.application.config.relative_url_root || '/'
+      root_url = Rails.application.config.relative_url_root || '/'
+      root_url = "/app#{root_url}" if root_url.exclude?('app') && Rails.env.production?
+      root_url
     end
   end
 end

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -4,6 +4,6 @@ module LrCommonStyles
   MAJOR = 1
   MINOR = 9
   PATCH = 1
-  SUFFIX = 1
+  SUFFIX = 2
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/test/dummy/config/environments/production.rb
+++ b/test/dummy/config/environments/production.rb
@@ -24,7 +24,7 @@ Rails.application.configure do
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.
-  config.serve_static_files = ENV['RAILS_SERVE_STATIC_FILES'].present?
+  config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier


### PR DESCRIPTION
This PR unifies different configurations settings between environments and applications. 

If an HMLR app is running in production mode, and the `RAILS_RELATIVE_URL_ROOT` configuration excludes `/app`, then the app name is appended to the relative_url_root of `/app` to ensure the paths point to the appropriate HMLR suite application location.

### Includes:

- refactor: updated static file setting to current format
- build: incremented version cadence
- docs: Updated Changelog entry


N.B. Once approved the gem will need to be published to the Epi packages