### PR TITLE
Update required_ruby_version gemspec

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ applications.
 
 ## Changes
 
+## 1.9.2 - 2023-11-23
+
+- (Jon) Resolves locked ruby version conflict created by using the `=` for the
+  `required_ruby_version` specification, this prevented associated rails apps
+  which are using a release version of ruby (e.g. `v2.6.6.146`) from building
+- (Jon) Incremented version cadence of gem from `v1.9.1.2` to `v1.9.2` to
+  reflect the changes made to the gemspec
+
 ## 1.9.1.2 - 2023-04-19
 
 - (Jon)  updated static file settings to current format

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,7 +3,7 @@
 module LrCommonStyles
   MAJOR = 1
   MINOR = 9
-  PATCH = 1
-  SUFFIX = 2
+  PATCH = 2
+  SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |s|
   s.summary     = 'LR Common Styles for Rails'
   s.description = 'Common elements of LR open data applications as a Rails engine'
   s.license     = 'MIT'
-  s.required_ruby_version = '= 2.6.6'
+  s.required_ruby_version = '~> 2.6.6'
 
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['test/**/*']


### PR DESCRIPTION
The PR resolves a locked ruby version conflict created by using the `=` for the `required_ruby_version` specification, which prevented associated rails apps that are using a "release" version of ruby (e.g. `v2.6.6.146`) from building