### PR TITLE
Common App menu link url resolution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ applications.
 
 ## Changes
 
+## 1.9.3 - 20232-11-27
+
+- (Jon) If the app is running in production, and the `relative_url_root` excludes
+  `/app`, then the app name is appended to the relative_url_root of `/app`
+  This resolves the urls paths for the apps from the landing page, but not
+  for the apps themselves
+
 ## 1.9.2 - 2023-11-23
 
 - (Jon) Resolves locked ruby version conflict created by using the `=` for the

--- a/app/models/lr_common_config.rb
+++ b/app/models/lr_common_config.rb
@@ -23,8 +23,14 @@ class LrCommonConfig
 
     # Returns the relative url root for the app if running in a subdirectory
     # of the web server, or the root if it is not
+    # If the app is running in production, and the relative_url_root excludes
+    # /app, then the app name is appended to the relative_url_root of `/app`
+    # This resolves the urls paths for the apps from the landing page, but not
+    # for the apps themselves
     def relative_url_root
-      Rails.application.config.relative_url_root || '/'
+      root_url = Rails.application.config.relative_url_root || '/'
+      root_url = "/app#{root_url}" if root_url.exclude?('app') && Rails.env.production?
+      root_url
     end
   end
 end

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,7 +3,7 @@
 module LrCommonStyles
   MAJOR = 1
   MINOR = 9
-  PATCH = 2
+  PATCH = 3
   SUFFIX = nil
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && ".#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR updates the gem to check if the app is running in production, and if the `relative_url_root` excludes `/app`; if so, then the app name is appended to the relative_url_root of `/app/` + app name
This resolves the urls paths for the apps from the landing page, but not for the apps themselves
