### PR TITLE
Incorrect root url for landing page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ applications.
 
 ## Changes
 
+## 1.9.7 - 2024-09
+
+- (Jon) Resolves issue with the root url `/`  being set to `/app/` when the
+  landing page app is running in production mode. This resolves the urls paths
+  for the apps to the landing page, but does not change the links to the apps
+  themselves.
+
 ## 1.9.6 - 2024-08
 
 - (Jon) Additional improvements for the suite of apps that use this gem to

--- a/app/models/lr_common_config.rb
+++ b/app/models/lr_common_config.rb
@@ -11,7 +11,7 @@ class LrCommonConfig
       # Set the css classes for the link if they are not set
       link_classes = set_link_classes(app_name, css_classes, root, request.original_url)
       # Sub replaces just the first instance of the app name in the relative_url_root
-      path = root ? relative_url_root : relative_url_root.sub(%r{[^/]*\Z}, app_name)
+      path = root ? app_name : relative_url_root.sub(%r{[^/]*\Z}, app_name)
       # Add the lang param if it exists
       path += "?lang=#{request.params[:lang]}" if request.params.key?(:lang)
       # if the app name is the same as the current app, set the path to the root

--- a/app/models/lr_common_config.rb
+++ b/app/models/lr_common_config.rb
@@ -13,7 +13,7 @@ class LrCommonConfig
       # Sub replaces just the first instance of the app name in the relative_url_root
       path = root ? app_name : relative_url_root.sub(%r{[^/]*\Z}, app_name)
       # Add the lang param if it exists
-      path += "?lang=#{request.params[:lang]}" if request.params.key?(:lang)
+      path += "?lang=#{request.params[:lang]}" if request.params[:lang].present?
       # if the app name is the same as the current app, set the path to the root
       t_name = root ? 'common.header.app_title' : "common.app.#{app_name}"
       # Set the link id if an id is required

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,7 +3,7 @@
 module LrCommonStyles
   MAJOR = 1
   MINOR = 9
-  PATCH = 6
+  PATCH = 7
   SUFFIX = nil # nil or 'rc' or 'beta' or 'alpha' for pre-release versions
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR resolves ticket #64 where the root url in the LR applications was being set to `/app/` instead of simply `/`