### PR TITLE
Task: Release v.1.9.9

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ applications.
 
 ## Changes
 
+## 1.9.9 - 2024-09
+
+- (Jon) Moved the `puma stats` haml to it's own partial as well as added the
+  `puma stats` partial to the footer of the application template. This will
+  allow the `puma stats` output to be displayed on the HMLR apps that use this
+  gem. The `puma stats` output will only be displayed in development mode.
+
 ## 1.9.8 - 2024-09
 
 - (Jon) Implemented the dependabot PR #55 to update jquery-rails requirement

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -49,3 +49,4 @@
           = render partial: "shared/feedback"
 
     = render partial: "shared/footer"
+    = render partial: "shared/puma_stats" if Rails.env.development?

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -30,8 +30,3 @@
       = succeed(':') do
         = I18n.t('common.footer.application_release')
       = Version::VERSION
-    - if Rails.env.development?
-      %pre
-        [puma stats:
-        = JSON.pretty_generate(JSON.parse(Puma.stats, symbolize_names: true))
-        , time: #{Time.now}]

--- a/app/views/shared/_puma_stats.html.haml
+++ b/app/views/shared/_puma_stats.html.haml
@@ -2,6 +2,4 @@
 %div
   %pre
     %code
-      [
-      = JSON.pretty_generate(puma_stats: JSON.parse(Puma.stats), time: Time.now)
-    ]
+      = "[#{JSON.pretty_generate(puma_stats: JSON.parse(Puma.stats), time: Time.now)}]"

--- a/app/views/shared/_puma_stats.html.haml
+++ b/app/views/shared/_puma_stats.html.haml
@@ -1,0 +1,7 @@
+
+%div
+  %pre
+    %code
+      [
+      = JSON.pretty_generate(puma_stats: JSON.parse(Puma.stats), time: Time.now)
+    ]

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,7 +3,7 @@
 module LrCommonStyles
   MAJOR = 1
   MINOR = 9
-  PATCH = 8
+  PATCH = 9
   SUFFIX = nil # nil or 'rc' or 'beta' or 'alpha' for pre-release versions
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}"
 end


### PR DESCRIPTION
This PR moves the `puma-stats` information displayed in the footer while in development to it's own partial for ease of future update.

![CleanShot 2024-09-17 at 13 58 44](https://github.com/user-attachments/assets/801435df-4e06-47ec-a077-b8ff0a66b83b)
