### PR TITLE
Spike/govuk elements fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ applications.
 
 ## Changes
 
+## 2.1.1 - 2024-10
+
+- (Bogdan) Added version specification for the `govuk_elements_rails` gem. This
+  is because all later versions have a symlink bug. Also, the gem is deprecated
+  and will receive no further updates.
+
 ## 2.1.0 - 2024-10
 
 - (Bogdan) Upgraded rails to latest version (`7.2.1`)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     lr_common_styles (2.1.0)
       bootstrap-sass
       font-awesome-rails
-      govuk_elements_rails
+      govuk_elements_rails (= 3.0.2)
       govuk_frontend_toolkit
       govuk_template
       haml-rails
@@ -117,13 +117,12 @@ GEM
       railties (>= 3.2, < 8.0)
     globalid (1.2.1)
       activesupport (>= 6.1)
-    govuk_elements_rails (2.0.0)
-      govuk_frontend_toolkit (>= 4.14.1)
+    govuk_elements_rails (3.0.2)
+      govuk_frontend_toolkit (>= 5.2.0)
       rails (>= 4.1.0)
       sass (>= 3.2.0)
-    govuk_frontend_toolkit (4.18.4)
-      rails (>= 3.1.0)
-      sass (>= 3.2.0)
+    govuk_frontend_toolkit (9.0.1)
+      railties (>= 3.1.0)
     govuk_template (0.18.3)
       rails (>= 3.1)
     haml (6.3.0)

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -3,7 +3,7 @@
 module LrCommonStyles
   MAJOR = 2
   MINOR = 1
-  PATCH = 0
+  PATCH = 1
   SUFFIX = nil # nil or 'rc' or 'beta' or 'alpha' for pre-release versions
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}"
 end

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -25,6 +25,10 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'font-awesome-rails'
+  # There is a bug with a missing symlink in all 3.1 versions.
+  # There is an open PR to fix this here: https://github.com/alphagov/govuk_elements_rails/pull/38.
+  # However, the gem has been deprecated and is no longer maintained, and because LR Common Styles is a gem as well,
+  # we cannot use a forked repo as a dependency. As a result we are stuck on version 3.0.2.
   s.add_dependency 'govuk_elements_rails', '3.0.2'
   s.add_dependency 'govuk_frontend_toolkit'
   s.add_dependency 'govuk_template'

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency 'bootstrap-sass'
   s.add_dependency 'font-awesome-rails'
-  s.add_dependency 'govuk_elements_rails'
+  s.add_dependency 'govuk_elements_rails', '3.0.2'
   s.add_dependency 'govuk_frontend_toolkit'
   s.add_dependency 'govuk_template'
   s.add_dependency 'haml-rails'


### PR DESCRIPTION
This PR adds version specification for the `govuk_elements_rails` gem (`3.0.2`). This is the latest version that doesn't have the symlink bug: https://github.com/alphagov/govuk_elements_rails/issues/33 . Although marked as fixed the bug is still present and there is an open PR about it: https://github.com/alphagov/govuk_elements_rails/pull/38 . However, the gem is no longer maintained and will receive no further updates. Because LR Common Styles is a gem as well, we cannot use a forked repo as a dependency. As a result we are stuck on version `3.0.2`. This will eventually need replacing, and likely to involve code changes as well