### PR TITLE
Task: Update GA4 Tracking code on all LR apps 

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    lr_common_styles (2.1.5)
+    lr_common_styles (2.2.0)
       bootstrap-sass
       font-awesome-rails
       govuk_elements_rails (= 3.0.2)
@@ -354,4 +354,4 @@ DEPENDENCIES
   rubocop-rails
 
 BUNDLED WITH
-   2.6.8
+   2.6.9

--- a/app/assets/javascripts/lr_common_styles/cookie.js
+++ b/app/assets/javascripts/lr_common_styles/cookie.js
@@ -1,6 +1,7 @@
 const HMLR_COOKIE_POLICY = 'hmlr_cookie_policy'
 const COOKIE_DURATION = 365
-const GA_TRACKING_ID = 'UA-21165003-6' // Maybe better from an env var?
+const GA_TRACKING_ID = document.documentElement.dataset.gaId //passed from Rails to JS via Data Attributes
+GA_TRACKING_ID !== undefined && delete document.documentElement.dataset.gaId; // Remove the ga_id data attribute
 const isProduction = document.documentElement.dataset.railsEnv === 'production'
 isProduction !== undefined && delete document.documentElement.dataset.railsEnv; // Remove the rails_env data attribute
 
@@ -174,6 +175,7 @@ const loadAnalytics = async (inProduction = false) => {
     // Check if the environment is production
     if (!inProduction) {
       console.log('Not in production, skipping Google Analytics initialization');
+      console.debug('Google Analytics ID:', GA_TRACKING_ID);
       return;
     }
     await loadGoogleAnalyticsScript(); // Wait for GA script to load

--- a/app/assets/javascripts/lr_common_styles/cookie.js
+++ b/app/assets/javascripts/lr_common_styles/cookie.js
@@ -1,9 +1,9 @@
 const HMLR_COOKIE_POLICY = 'hmlr_cookie_policy'
 const COOKIE_DURATION = 365
-const GA_TRACKING_ID = document.documentElement.dataset.gaId //passed from Rails to JS via Data Attributes
-GA_TRACKING_ID !== undefined && delete document.documentElement.dataset.gaId; // Remove the ga_id data attribute
-const isProduction = document.documentElement.dataset.railsEnv === 'production'
-isProduction !== undefined && delete document.documentElement.dataset.railsEnv; // Remove the rails_env data attribute
+const GA_TRACKING_ID = document.documentElement.dataset.gaId // passed from Rails to JS via Data Attributes
+GA_TRACKING_ID !== undefined && delete document.documentElement.dataset.gaId // Remove the ga_id data attribute
+const inProduction = document.documentElement.dataset.railsEnv === 'production'
+inProduction !== undefined && delete document.documentElement.dataset.railsEnv // Remove the rails_env data attribute
 
 /**
  * Retrieve user preferences cookie
@@ -19,7 +19,7 @@ window.onload = function () {
     const analyticsAccepted = JSON.parse(userPreferences).analytics
 
     if (analyticsAccepted) {
-      loadAnalytics(isProduction)
+      loadAnalytics(inProduction)
     }
   } else {
     showBanner(true)
@@ -38,10 +38,10 @@ window.onload = function () {
  * Finally, it sets the cookie with the specified key and value, along with the expiration date and path.
  * The cookie is set to expire after the specified duration in days.
  */
-function setCookie(key, value, duration) {
-  const date = new Date();
-  date.setTime(date.getTime() + duration * 24 * 60 * 60 * 1000);
-  const expires = 'expires=' + date.toUTCString();
+function setCookie (key, value, duration) {
+  const date = new Date()
+  date.setTime(date.getTime() + duration * 24 * 60 * 60 * 1000)
+  const expires = 'expires=' + date.toUTCString()
   document.cookie = key + '=' + value + ';' + expires + ';path=/'
 }
 
@@ -55,38 +55,42 @@ function setCookie(key, value, duration) {
  * If a match is found, it returns the value of the cookie.
  * If no match is found, it returns an empty string.
  */
-function getCookie(name) {
-  const key = name + '=';
-  const decodedCookie = decodeURIComponent(document.cookie);
-  const cookieList = decodedCookie.split(';');
+function getCookie (name) {
+  const key = name + '='
+  const decodedCookie = decodeURIComponent(document.cookie)
+  const cookieList = decodedCookie.split(';')
   for (let i = 0; i < cookieList.length; i++) {
-    const cookie = cookieList[i]
+    let cookie = cookieList[i]
     while (cookie.charAt(0) == ' ') {
-      cookie = cookie.substring(1);
+      cookie = cookie.substring(1)
     }
     if (cookie.indexOf(key) == 0) {
-      return cookie.substring(key.length, cookie.length);
+      return cookie.substring(key.length, cookie.length)
     }
   }
-  return '';
+  return ''
 }
 
 /**
  * Set analytics acceptance cookie to true
  * @returns {void}
  * @description This function sets the analytics acceptance cookie to true.
+ * called from app/views/common/_cookie_banner.html.haml
  */
-function acceptCookie() {
-  acceptAnalytics(true);
+// eslint-disable-next-line no-unused-vars
+function acceptCookie () {
+  acceptAnalytics(true)
 }
 
 /**
  * Set analytics acceptance cookie to false
  * @returns {void}
  * @description This function sets the analytics acceptance cookie to false.
+ * called from app/views/common/_cookie_banner.html.haml
  */
-function rejectCookie() {
-  acceptAnalytics(false);
+// eslint-disable-next-line no-unused-vars
+function rejectCookie () {
+  acceptAnalytics(false)
 }
 
 /**
@@ -99,8 +103,8 @@ function rejectCookie() {
  * The function uses the `setAttribute` method to set the display style of the cookie banner.
  * The cookie banner is identified by its ID 'cookie-banner'.
  */
-function showBanner(bool) {
-  let cookieBanner = document.getElementById('cookie-banner');
+function showBanner (bool) {
+  const cookieBanner = document.getElementById('cookie-banner')
   if (!cookieBanner) return // If the cookie banner is not found, exit the function
   if (bool) {
     cookieBanner.setAttribute('style', 'display:block')
@@ -118,14 +122,14 @@ function showBanner(bool) {
  * If the boolean value is true, it loads the analytics script.
  * If the boolean value is false, it does not load the analytics script.
  */
-function acceptAnalytics(bool) {
+function acceptAnalytics (bool) {
   const preferences = { analytics: bool }
 
   setCookie(HMLR_COOKIE_POLICY, JSON.stringify(preferences), COOKIE_DURATION)
   showBanner(false)
 
   if (bool) {
-    loadAnalytics(isProduction)
+    loadAnalytics(inProduction)
   }
 }
 
@@ -142,22 +146,34 @@ function acceptAnalytics(bool) {
  * The function also logs messages to the console to indicate the status of the script loading process.
  * The script is loaded from the Google Tag Manager URL with the specified tracking ID.
  */
-function loadGoogleAnalyticsScript(){
+function loadGoogleAnalyticsScript () {
   return new Promise((resolve, reject) => {
     // Create the script element for Google Analytics
-    const script = document.createElement('script');
-    script.async = true;
-    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`;
-    script.onerror = reject; // Reject the promise if there is an error loading the script
-    script.onload = resolve; // Resolve the promise when the script is loaded
-    document.head.appendChild(script); // Append the script to the document head if loaded successfully
+    const script = document.createElement('script')
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`
+    script.onerror = reject // Reject the promise if there is an error loading the script
+    script.onload = resolve // Resolve the promise when the script is loaded
+    document.head.appendChild(script) // Append the script to the document head if loaded successfully
     script.addEventListener('load', () => {
-      !inProduction && console.log('Google Analytics script loaded successfully');
-    });
+      !inProduction && console.log('Google Analytics script loaded successfully')
+    })
     script.addEventListener('error', () => {
-      console.error('Error loading Google Analytics script');
-    });
-  });
+      console.error('Error loading Google Analytics script')
+    })
+  })
+}
+
+/**
+* Function to send data to Google Analytics
+* @param {...*} arguments - The arguments to be sent to Google Analytics.
+* @description This function is used to send data to Google Analytics.
+* It pushes the arguments to the dataLayer array, which is used by Google Tag Manager.
+* It is defined as a global function so that it can be called from anywhere in the code.
+*/
+function gtag () {
+  const dataLayer = window.dataLayer || []
+  dataLayer.push(arguments)
 }
 
 /**
@@ -174,17 +190,15 @@ const loadAnalytics = async (inProduction = false) => {
   try {
     // Check if the environment is production
     if (!inProduction) {
-      console.log('Not in production, skipping Google Analytics initialization');
-      console.debug('Google Analytics ID:', GA_TRACKING_ID);
-      return;
+      console.log('Not in production, skipping Google Analytics initialization')
+      console.debug('Google Analytics ID:', GA_TRACKING_ID)
+      return
     }
-    await loadGoogleAnalyticsScript(); // Wait for GA script to load
+    await loadGoogleAnalyticsScript() // Wait for GA script to load
     // Initialize Google Analytics
-    window.dataLayer = window.dataLayer || [];
-    function gtag(){dataLayer.push(arguments);}
-    gtag('js', new Date());
-    gtag('config', GA_TRACKING_ID , { 'anonymize_ip': true });
+    gtag('js', new Date())
+    gtag('config', GA_TRACKING_ID, { anonymize_ip: true })
   } catch (error) {
-    console.error('Error loading Google Analytics:', error);
+    console.error('Error loading Google Analytics:', error)
   }
 }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -1,4 +1,4 @@
-%html{ lang: 'en', data: { 'rails-env': Rails.env } }
+%html{ lang: 'en', data: { 'rails-env': Rails.env, GA_ID: Rails.application.config.google_analytics_id} }
   %head
     %meta{ charset: 'utf-8' }
     %meta{ 'http-equiv' => 'x-ua-compatible', content: 'ie=edge' }

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -4,7 +4,8 @@
     %meta{ 'http-equiv' => 'x-ua-compatible', content: 'ie=edge' }
     %meta{ name: 'viewport', content: 'width=device-width, initial-scale=1, shrink-to-fit=no' }
     %title
-      = (yield(:title) + " - " unless yield(:title).blank?).to_s + I18n.t('common.header.app_title')
+      = ( yield(:title) + " - " unless yield(:title).blank?).to_s
+      = I18n.t('common.header.app_title')
 
     = javascript_include_tag :modernizr, async: true
     = stylesheet_link_tag "application", media: "all"

--- a/config/initializers/lr_common_styles_config.rb
+++ b/config/initializers/lr_common_styles_config.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-# Configuration initializer for LR Common Styles gem
+# Configuration initialiser for LR Common Styles gem
 Rails.application.config.tap do |config|
   # Set the Google Analytics ID, if available
   # This can be set in the environment variables or left as nil

--- a/config/initializers/lr_common_styles_config.rb
+++ b/config/initializers/lr_common_styles_config.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+# Configuration initializer for LR Common Styles gem
+Rails.application.config.tap do |config|
+  # Set the Google Analytics ID, if available
+  # This can be set in the environment variables or left as nil
+  config.google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_ID', nil)
+end

--- a/config/initializers/lr_common_styles_config.rb
+++ b/config/initializers/lr_common_styles_config.rb
@@ -3,6 +3,7 @@
 # Configuration initialiser for LR Common Styles gem
 Rails.application.config.tap do |config|
   # Set the Google Analytics ID, if available
-  # This can be set in the environment variables or left as nil
-  config.google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_ID', nil)
+  # This can be set in the environment variables or left as old value
+  # for backwards compatibility.
+  config.google_analytics_id = ENV.fetch('GOOGLE_ANALYTICS_ID', 'UA-21165003-6')
 end

--- a/lib/lr_common_styles/version.rb
+++ b/lib/lr_common_styles/version.rb
@@ -2,8 +2,8 @@
 
 module LrCommonStyles
   MAJOR = 2
-  MINOR = 1
-  PATCH = 5
+  MINOR = 2
+  PATCH = 0
   SUFFIX = nil # nil or 'rc' or 'beta' or 'alpha' for pre-release versions
   VERSION = "#{MAJOR}.#{MINOR}.#{PATCH}#{SUFFIX && "-#{SUFFIX}"}".freeze
 end


### PR DESCRIPTION
This update refactors the way Google Analytics ID is handled by implementing data attribute retrieval from HTML, and creates a configuration initialiser for setting the GA ID from environment variables. It also adds enhancements to HTML for data attributes supporting GA setup.

Specific to ticket [#154](https://github.com/epimorphics/hmlr-linked-data/issues/154)

## Changes

- Replaced hardcoded GA ID with retrieval from a data attribute in the HTML.
  - Added fallback value for GA ID
- Added deletion of used data attributes after they are utilized.
- Initiated a configuration initializer to set Google Analytics ID using environment variables.
- Enhanced HTML attributes to include GA ID for script access.

## Impact

- The GA ID is now dynamically injected and managed through initialisation in Rails, reducing potential hardcoding issues.
- Dependencies on environment variables for GA ID, increasing the flexibility and configurability.
- No apparent breaking changes.
- Slight behavioural change in analytic script loading, reducing potential logging when not in production.