### PR TITLE
Task: Updates gem dependencies and configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,7 @@ Metrics/AbcSize:
   Max: 30
   Exclude:
     - test/**/*
+
 Metrics/BlockLength:
   Max: 30
   Exclude:

--- a/Gemfile
+++ b/Gemfile
@@ -7,30 +7,24 @@ gemspec
 
 # Bundler will treat runtime dependencies like base dependencies, and
 # development dependencies will be added by default to the :development group.
+group :maintenance do
+  # Runtime dependencies for this gem (as declared in the gemspec) are included
+  # here to allow bundler to validate when running the `bundle outdated
+  # --only-explicit` from the `make update` target.
 
-gem 'rails', '~> 8.0'
-
-# ! There is a bug with a missing symlink in all 3.1 versions of
-# ! "govuk_elements_rails". There is an open PR to fix this here:
-# ! https://github.com/alphagov/govuk_elements_rails/pull/38. However, the gem
-# ! has been deprecated and is no longer maintained, and because LR Common
-# ! Styles is a gem as well, we cannot use a forked repo as a dependency. As a
-# ! result we are stuck using version 3.0.2 until further investigations provide
-# ! a better solution.
-gem 'govuk_elements_rails', '3.0.2'
-gem 'govuk_frontend_toolkit', '~> 9.0'
-gem 'govuk_template', '~> 0.26.0'
-
-# Asset compilation tools (dartsass-sprockets, autoprefixer-rails) are
-# development-only for this gem. Consuming applications manage asset
-# compilation independently with their own configurations and tooling.
-gem 'bootstrap', '~> 5.3.2'
-gem 'font-awesome-rails', '~> 4.7.0'
-gem 'haml-rails', '~> 3.0'
-gem 'jquery-rails', '~> 4.6'
-gem 'lodash-rails', '~> 4.17'
-gem 'modernizr-rails', '~> 2.7'
-gem 'modulejs-rails', '~> 2.2.0'
+  # Versions should be kept in sync with those in the .gemspec
+  gem 'rails', '~> 8.0'
+  gem 'govuk_elements_rails', '3.0.2'
+  gem 'govuk_frontend_toolkit', '~> 9.0'
+  gem 'govuk_template', '~> 0.26.0'
+  gem 'bootstrap', '~> 5.3.2'
+  gem 'font-awesome-rails', '~> 4.7.0'
+  gem 'haml-rails', '~> 3.0'
+  gem 'jquery-rails', '~> 4.6'
+  gem 'lodash-rails', '~> 4.17'
+  gem 'modernizr-rails', '~> 2.7'
+  gem 'modulejs-rails', '~> 2.2.0'
+end
 
 # Declare any dependencies that are used in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,17 @@ PATH
   remote: .
   specs:
     lr_common_styles (3.0.1)
+      bootstrap (~> 5.3.2)
+      font-awesome-rails (~> 4.7.0)
+      govuk_elements_rails (= 3.0.2)
+      govuk_frontend_toolkit (~> 9.0)
+      govuk_template (~> 0.26.0)
+      haml-rails (~> 3.0)
+      jquery-rails (~> 4.6)
+      lodash-rails (~> 4.17)
+      modernizr-rails (~> 2.7)
+      modulejs-rails (~> 2.2.0)
+      rails (~> 8.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -10,10 +10,13 @@ details.
 ## Developer notes
 
 > [!IMPORTANT]
-> Gem dependencies are now recorded in the Gemfile, not in the .gemspec, due to
-> a "quirk" with the `bundler outdated` utility not checking gems listed in the
-> .gemspec while running the `make update` target command which uses the
+> Gem dependencies are now recorded BOTH in the Gemfile, AND in the .gemspec,
+> due to a "quirk" with the `bundler outdated` utility not checking gems listed
+> in the .gemspec while running the `make update` target command which uses the
 > `--only-explicit` flag[^1].
+
+> [!CAUTION]
+> Please be sure to mirror manual version updates to both locations.
 
 [^1]: <https://bundler.io/man/bundle-outdated.1.html>
 

--- a/lr_common_styles.gemspec
+++ b/lr_common_styles.gemspec
@@ -24,4 +24,31 @@ Gem::Specification.new do |spec|
   spec.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
 
   spec.metadata['rubygems_mfa_required'] = 'true'
+
+  # Runtime dependencies for this gem are ALSO included in the Gemfile's
+  # :maintenance group to allow bundler to validate when running the `bundle
+  # outdated --only-explicit` from the `make update` target.
+  spec.add_dependency 'rails', '~> 8.0'
+
+  # ! There is a bug with a missing symlink in all 3.1 versions of
+  # ! "govuk_elements_rails". There is an open PR to fix this here:
+  # ! https://github.com/alphagov/govuk_elements_rails/pull/38. However, the gem
+  # ! has been deprecated and is no longer maintained, and because LR Common
+  # ! Styles is a gem as well, we cannot use a forked repo as a dependency. As a
+  # ! result we are stuck using version 3.0.2 until further investigations provide
+  # ! a better solution.
+  spec.add_dependency 'govuk_elements_rails', '3.0.2'
+  spec.add_dependency 'govuk_frontend_toolkit', '~> 9.0'
+  spec.add_dependency 'govuk_template', '~> 0.26.0'
+
+  # Asset compilation tools (dartsass-sprockets, autoprefixer-rails) are
+  # development-only for this gem. Consuming applications manage asset
+  # compilation independently with their own configurations and tooling.
+  spec.add_dependency 'bootstrap', '~> 5.3.2'
+  spec.add_dependency 'font-awesome-rails', '~> 4.7.0'
+  spec.add_dependency 'haml-rails', '~> 3.0'
+  spec.add_dependency 'jquery-rails', '~> 4.6'
+  spec.add_dependency 'lodash-rails', '~> 4.17'
+  spec.add_dependency 'modernizr-rails', '~> 2.7'
+  spec.add_dependency 'modulejs-rails', '~> 2.2.0'
 end


### PR DESCRIPTION
This pull request ensures gem dependencies are consistently managed between the gemspec and Gemfile for accurate dependency auditing. It introduces a maintenance group in the Gemfile to align gem versions and clarifies dependency management in the README for developers.

## What's changed:

-   Groups runtime dependencies within a `:maintenance` group in the `Gemfile` to enable accurate dependency validation during `bundle outdated` checks, which helps maintain up-to-date gem versions.
-   Mirrors gem dependencies in both the `.gemspec` and the `Gemfile` to address a Bundler quirk where only gems specified in the `Gemfile` are checked when using `bundle outdated --only-explicit`.
-   Documents the dual dependency declaration approach in the `README` file, clarifying why gems are listed in both the `Gemfile` and `.gemspec`.
-   Adds a line break in `.rubocop.yml` for improved code readability.

Relates to #96